### PR TITLE
Auto-load default songs from bundled CSV

### DIFF
--- a/app/src/main/assets/default_songs.csv
+++ b/app/src/main/assets/default_songs.csv
@@ -1,0 +1,443 @@
+title,artist,year,Album,YouTube,code,image
+Schwanzwald ,Nanowar of Steel ,2014,A Knight at the Opera,https://music.youtube.com/watch?v=_jLuAOLhkMA,anghi0m001,QR/anghi0m001.png
+2 Minutes to Midnight,Iron Maiden,1984,Powerslave,https://music.youtube.com/watch?v=YCmUqAffWS8&si=3nIXnAESrjlrDsUy,anghi0m002,QR/anghi0m002.png
+512,Lamb of God,2015,VII: Sturm und Drang,https://music.youtube.com/watch?v=cFXtQ0mMMEE&si=0ucOhAA2BL_bmpxe,anghi0m003,QR/anghi0m003.png
+A Dying Wish,Thulcandra,2021,A Dying Wish,https://music.youtube.com/watch?v=RlIJO5PF-gE&si=5DRnjfPyMZLu1PFs,anghi0m004,QR/anghi0m004.png
+A Tout le Monde,Megadeth,1994,Youthanasia,https://music.youtube.com/watch?v=dPvMSvruNhM&si=id0QKkmVY54ooWp0,anghi0m005,QR/anghi0m005.png
+Abbey of Synn,Ayreon ,1996,Actual Fantasy,https://music.youtube.com/watch?v=lWYBqOVO4o0&si=HWFQl0nPROoo4-bt,anghi0m006,QR/anghi0m006.png
+Ace of Spades,Motörhead,1980,Ace of Spades,https://music.youtube.com/watch?v=wQchKv6OSQA&si=8CL7-92l3TTojsnW,anghi0m007,QR/anghi0m007.png
+Adrenalize,In This Moment,2012,Blood,https://music.youtube.com/watch?v=Wl_7U4nxZSk&si=xx40WI5ueWDrd-oF,anghi0m008,QR/anghi0m008.png
+Agent Orange,Sodom,1989,Agent Orange,https://music.youtube.com/watch?v=CjP2HZ4-5ps&si=9k0JYqf3sFSbnF2o,anghi0m009,QR/anghi0m009.png
+Ain’t Talkin’ ’Bout Love,Van Halen,1978,Van Halen,https://music.youtube.com/watch?v=qtwBFz6lfrY&si=hIuFUZXROi22cqwd,anghi0m010,QR/anghi0m010.png
+All Out Life,Slipknot,2018,All Out Life (Single),https://music.youtube.com/watch?v=9Ncd1har8tY&si=iCZt5UPzrvMWez7w,anghi0m011,QR/anghi0m011.png
+Alter mann,Knorkator ,2007,Das Nächste Album aller Zeiten ,https://music.youtube.com/watch?v=7ZM0hL_wdCY&si=07MjD0SKqekqLtql,anghi0m012,QR/anghi0m012.png
+Am I Evil?,Diamond Head,1980,Lightning to the Nations,https://music.youtube.com/watch?v=AeYHMxAZzv0&si=HDkbGKodWv97CQO_,anghi0m013,QR/anghi0m013.png
+Amazonia,Gojira,2021,Fortitude,https://music.youtube.com/watch?v=RXK8bUgVm9I&si=hV1ZIbvx-L0YAc-H,anghi0m014,QR/anghi0m014.png
+Amok Run,Kreator,2009,Hordes of Chaos,https://music.youtube.com/watch?v=TUPQz7tzNeM&si=uvSfExnSNRZmgJ4V,anghi0m015,QR/anghi0m015.png
+An then there was silence ,Blind Guardian ,2002,A Night at the Opera,https://music.youtube.com/watch?v=JpbRVR_hXkQ&si=JTMQ0FeNbxzOkrab,anghi0m016,QR/anghi0m016.png
+And the druids turn to stone ,Ayreon ,2000,Universal Migrator Part 1: The Dream Sequencer,https://music.youtube.com/watch?v=djdIuhwU8J4&si=fqVJfowQWAVfd19B,anghi0m017,QR/anghi0m017.png
+Angel of Death,Slayer,1986,Reign in Blood,https://music.youtube.com/watch?v=TnRZhLRv6eM&si=6OmFKWPoQgHqSsyq,anghi0m018,QR/anghi0m018.png
+Angel Witch,Angel Witch,1980,Angel Witch,https://music.youtube.com/watch?v=8oZpW3wyiWI&si=KIx_rCd3A7rvz8lu,anghi0m019,QR/anghi0m019.png
+Angus Mcfife,Gloryhammer ,2013,Tales from the Kingdom of Fife,https://music.youtube.com/watch?v=YkP02Fd44U8&si=ecpCuCPLlPYsPvq_,anghi0m020,QR/anghi0m020.png
+Animals,Architects,2021,For Those That Wish to Exist,https://music.youtube.com/watch?v=XkYPPUK5jos&si=dBu-nsYny3kKOKzE,anghi0m021,QR/anghi0m021.png
+Are You Dead Yet?,Children of Bodom,2005,Are You Dead Yet?,https://music.youtube.com/watch?v=VgZ9x76LrUs&si=TUiE13Q2mFombAQR,anghi0m022,QR/anghi0m022.png
+Armageddon ,Gamma Ray ,1999,Power Plant,https://music.youtube.com/watch?v=s3v_Mc3ItPU&si=UpEW8n2kbPmBMqYn,anghi0m023,QR/anghi0m023.png
+As I Die,Paradise Lost,1992,Shades of God,https://music.youtube.com/watch?v=hZxCPHfRCOw&si=zm-EEZ4_K5BAuOa7,anghi0m024,QR/anghi0m024.png
+Sacred Worlds,Blind Guardian,2010,At the Edge of Time,https://music.youtube.com/watch?v=e6Y2qGK--NI&si=emPr1l5Y1UoKsbAm,anghi0m025,QR/anghi0m025.png
+Augen auf!,Oomph!,2004,Wahrheit oder Pflicht,https://music.youtube.com/watch?v=9DXXAIoz9tI&si=HFidMsojmlydZfha,anghi0m026,QR/anghi0m026.png
+B.Y.O.B.,System of a Down,2005,Mezmerize,https://music.youtube.com/watch?v=OMtq6JzREcA&si=QMKr825Jq4an6NqS,anghi0m027,QR/anghi0m027.png
+Backbone,Gojira,2005,From Mars to Sirius,https://music.youtube.com/watch?v=eoQrdQ0MXYw&si=NvdKpMPQyiPKxZ77,anghi0m028,QR/anghi0m028.png
+Balls to the Wall,Accept,1983,Balls to the Wall,https://music.youtube.com/watch?v=R-F31GvvPYw&si=YCuBr-R5FInBOdBa,anghi0m029,QR/anghi0m029.png
+Bat Country,Avenged Sevenfold,2005,City of Evil,https://music.youtube.com/watch?v=NJ2regeDoJw&si=0n-bR3mE_EMIV7g1,anghi0m030,QR/anghi0m030.png
+Bat Out of Hell,Meat Loaf,1977,Bat Out of Hell,https://music.youtube.com/watch?v=x7ES7ueI7p0&si=PTJPvN_DC-F86l37,anghi0m031,QR/anghi0m031.png
+Battery,Metallica,1986,Master of Puppets,https://music.youtube.com/watch?v=uzlOcupu5UE&si=8rOPOnVIZ7S4ThJq,anghi0m032,QR/anghi0m032.png
+Bestial Invasion,Destruction,1985,Infernal Overkill,https://music.youtube.com/watch?v=XIEeZFjFEmM&si=oZmHR0YcjmjJDCSO,anghi0m033,QR/anghi0m033.png
+Betrayer,Trivium,2017,The Sin and the Sentence,https://music.youtube.com/watch?v=eyNWwE8I7rM&si=M8xpuSkE3NZKvBGx,anghi0m034,QR/anghi0m034.png
+Beyond the Realms of Death,Judas Priest,1978,Stained Class,https://music.youtube.com/watch?v=MtWJoIUifQI&si=auvK3RhIhmoJ0JZJ,anghi0m035,QR/anghi0m035.png
+Big Bad Wolf,In This Moment,2014,Black Widow,https://music.youtube.com/watch?v=5r2jZWqnQLo&si=oWqravJNk6gbA7YC,anghi0m036,QR/anghi0m036.png
+Bismarck,Sabaton,2019,The Great War,https://music.youtube.com/watch?v=n4zAyyh5VLo&si=5gxxLtHi8-K-GWlQ,anghi0m037,QR/anghi0m037.png
+Black Metal,Venom,1982,Black Metal,https://music.youtube.com/watch?v=tjbMJUEPUUs&si=HPrH3hJHSBfvQV7B,anghi0m038,QR/anghi0m038.png
+Black Ninja ,Battle Beast ,2013,Battle Beast ,https://music.youtube.com/watch?v=a_F20iAa-l8&si=3x-9Ai4CHuEZLi1_,anghi0m039,QR/anghi0m039.png
+Black No. 1,Type O Negative,1993,Bloody Kisses,https://music.youtube.com/watch?v=JmijMVT3x-0&si=thFaQa4mIbcFkEl9,anghi0m040,QR/anghi0m040.png
+Black Sabbath,Black Sabbath,1970,Black Sabbath,https://music.youtube.com/watch?v=8lsYurpPvDk&si=N6CfJ05aWm5-Q8N5,anghi0m041,QR/anghi0m041.png
+Black Sun,Primal Fear,2002,Black Sun,https://music.youtube.com/watch?v=CepCefRQtR4&si=GyY53OhLIok4saa-,anghi0m042,QR/anghi0m042.png
+Black Winter Day,Amorphis,1995,Tales from the Thousand Lakes,https://music.youtube.com/watch?v=uwG0xX-EsBc&si=wkFV9Jc4axNncMib,anghi0m043,QR/anghi0m043.png
+Blackwater Park,Opeth,2001,Blackwater Park,https://music.youtube.com/watch?v=2w_vYwrn4lc&si=foVIZiuaybuSrRNm,anghi0m044,QR/anghi0m044.png
+Blau wie das Meer ,Mr. Hurley und die Pulveraffen ,2012,Affentheater,https://music.youtube.com/watch?v=jLIYYa7DUhY&si=WWtH_xoYMhwWmiRv,anghi0m045,QR/anghi0m045.png
+Bleeding Mascara,Atreyu,2004,The Curse,https://music.youtube.com/watch?v=HqRNcHTgEb8&si=VU7V_zg67em5Mp9B,anghi0m046,QR/anghi0m046.png
+Blind,Korn,1994,Korn,https://music.youtube.com/watch?v=x81SMw8qUh0&si=jp8wQq1IGiXN7JSg,anghi0m047,QR/anghi0m047.png
+I Wanna Be Somebody,W.A.S.P.,1984,W.A.S.P.,https://music.youtube.com/watch?v=pAcxNO1YV60&si=6AhhG3AtZe0FKb6v,anghi0m048,QR/anghi0m048.png
+Blinded by Fear,At the Gates,1995,Slaughter of the Soul,https://music.youtube.com/watch?v=0oJFV3lc2TQ&si=SUhh7nLGQyFd8TaP,anghi0m049,QR/anghi0m049.png
+Blood and Thunder,Mastodon,2004,Leviathan,https://music.youtube.com/watch?v=fnwZca8z9II&si=482NTxqsdf3MlnB-,anghi0m050,QR/anghi0m050.png
+Blood Dynasty ,Arch Enemy,2025,Blood Dynasty ,https://music.youtube.com/watch?v=YKbw-PyVNyw&si=qEM5DYsnJiFUSy6o,anghi0m051,QR/anghi0m051.png
+Blood Eagle,Periphery,2019,Periphery IV: Hail Stan,https://music.youtube.com/watch?v=sf4oYHSBD4M&si=yXic0w2XtXbtNgjW,anghi0m052,QR/anghi0m052.png
+"Blood In, Blood Out",Exodus,2014,"Blood In, Blood Out",https://music.youtube.com/watch?v=69opS6frcyQ&si=OhKJ6Owikff0Ht4G,anghi0m053,QR/anghi0m053.png
+Bloodmeat,Protest the Hero,2008,Fortress,https://music.youtube.com/watch?v=1d9PsqPrBME&si=Z0W8IkuyQEaLETOs,anghi0m054,QR/anghi0m054.png
+Bodom After Midnight,Children of Bodom,2000,Follow the Reaper,https://music.youtube.com/watch?v=1naxQzchOOw&si=89cfG9t3wlwrgymA,anghi0m055,QR/anghi0m055.png
+Bombenhagel,Sodom,1987,Persecution Mania,https://music.youtube.com/watch?v=8DGxwmP7uLI&si=zGSAPe8_Y734rjA8,anghi0m056,QR/anghi0m056.png
+Born to be wild,Steppenwolf,1968,Steppenwolf,https://music.youtube.com/watch?v=93fAJe8WVjA&si=WSjDocNZL2MZigah,anghi0m057,QR/anghi0m057.png
+Breadfan,Budgie,1973,Never Turn Your Back on a Friend,https://music.youtube.com/watch?v=4aTASJIMSJI&si=OhCWsrxxNjl57c0N,anghi0m058,QR/anghi0m058.png
+Break Stuff,Limp Bizkit,1999,Significant Other,https://music.youtube.com/watch?v=jd_HmLEhVqA&si=JaEf5NTOV_5HU9mg,anghi0m059,QR/anghi0m059.png
+Breaking the Law,Judas Priest,1980,British Steel,https://music.youtube.com/watch?v=BXtPycm5dGc&si=xSDCAe-vQ1raofbX,anghi0m060,QR/anghi0m060.png
+Bring the noise,Anthrax,1991,Attack of the Killer B's (compilation),https://music.youtube.com/watch?v=YhpAcD8HI2g&si=wC1Xf_pb5D7Xwl64,anghi0m061,QR/anghi0m061.png
+Bulls on Parade,Rage Against the Machine,1996,Evil Empire,https://music.youtube.com/watch?v=DvdeE6KzrTc&si=qlNoJ5ODbk5VbXx_,anghi0m062,QR/anghi0m062.png
+Call Me Little Sunshine,Ghost,2022,"IMPERA
+ ",https://music.youtube.com/watch?v=1Df28_NCk6s&si=FRDHnBEJffG1E2Qt,anghi0m063,QR/anghi0m063.png
+Captain Morgan's revenge ,Alestorm ,2008,Captain Morgan's revenge ,https://music.youtube.com/watch?v=I1EGep8etJ4,anghi0m064,QR/anghi0m064.png
+Cars,Fear Factory,1999,Obsolete,https://music.youtube.com/watch?v=IZRDHXONrxA&si=RNnVleoylONGHj8L,anghi0m065,QR/anghi0m065.png
+Caught in a Mosh,Anthrax,1986,Among the Living,https://music.youtube.com/watch?v=XphUURIAx5g&si=HTQdy4eiZbzmHEL2,anghi0m066,QR/anghi0m066.png
+Ylem,Dark Fortress,2009,Ylem,https://music.youtube.com/watch?v=xfLb6s_kRe8&si=4oWSb-wo5EpCASEf,anghi0m067,QR/anghi0m067.png
+Cemetery Gates,Pantera,1990,Cowboys from Hell,https://music.youtube.com/watch?v=cSZf8ZYHV7o&si=oh0pJLJKxACCzHu2,anghi0m068,QR/anghi0m068.png
+Change (In the House of Flies),Deftones,2000,White Pony,https://music.youtube.com/watch?v=hzRltUL5M3k&si=CqLoniF7VHXN_jtR,anghi0m069,QR/anghi0m069.png
+Chapel of Ghouls,Morbid Angel,1989,Altars of Madness,https://music.youtube.com/watch?v=jOgQrKdNeNI&si=5S-cOyAc67FmChuP,anghi0m070,QR/anghi0m070.png
+Child in Time,Deep Purple,1970,Deep Purple in Rock,https://music.youtube.com/watch?v=FpA707p7w9A&si=bDIPsB6Zp6ZOG0zL,anghi0m071,QR/anghi0m071.png
+Children of the Grave,Black Sabbath,1971,Master of Reality,https://music.youtube.com/watch?v=chxt6iZHRTs&si=6fcSCmmGfhmkPFkY,anghi0m072,QR/anghi0m072.png
+Chop Suey!,System of a Down,2001,Toxicity,https://music.youtube.com/watch?v=MlcJQYON2Go&si=tjQ13IFpYtTO-7S1,anghi0m073,QR/anghi0m073.png
+Cirice,Ghost,2015,Meliora,https://music.youtube.com/watch?v=vcbOsoZXyDo&si=Y1rYM9Uax-otnOA3,anghi0m074,QR/anghi0m074.png
+Clockworks,Meshuggah,2016,The Violent Sleep of Reason,https://music.youtube.com/watch?v=QIao9RrOFbY&si=fFJxvsk_-VhwKXaW,anghi0m075,QR/anghi0m075.png
+Closer,Nine Inch Nails,1994,The Downward Spiral,https://music.youtube.com/watch?v=O7gRpIKfSCM&si=xUL9PKXrda2wgwcD,anghi0m076,QR/anghi0m076.png
+Cloud Connected,In Flames,2002,Reroute to Remain,https://music.youtube.com/watch?v=3iIQoPWm8ho&si=06GOkr9lmd4xmX6H,anghi0m077,QR/anghi0m077.png
+Cockroach King,Haken,2013,The Mountain,https://music.youtube.com/watch?v=tUa14ly7N8M&si=nD765qHQXz9RFSY9,anghi0m078,QR/anghi0m078.png
+Coma White,Marilyn Manson,1998,Mechanical Animals,https://music.youtube.com/watch?v=Uv_BzHMtT8E&si=bmvGrVP0lEYEIGti,anghi0m079,QR/anghi0m079.png
+Combustion,Meshuggah,2008,obZen,https://music.youtube.com/watch?v=fsIk5-ab38M&si=Xr_zIrVGoaOPhCsp,anghi0m080,QR/anghi0m080.png
+Constance,Spiritbox,2021,Eternal Blue,https://music.youtube.com/watch?v=YTgCwZTSGfQ&si=I3r9NDl8fQEZ1S9E,anghi0m081,QR/anghi0m081.png
+Crawling,Linkin Park,2000,Hybrid Theory,https://music.youtube.com/watch?v=I6NU3kWqnDE&si=tEflwafkzLFvJqP3,anghi0m082,QR/anghi0m082.png
+Crazy Crazy Nights,KISS,1987,Crazy Nights,https://music.youtube.com/watch?v=ktp41G_5JFQ&si=nl_9g5M_sLuqq9gu,anghi0m083,QR/anghi0m083.png
+Crazy train,Ozzy Osborne,1980,Blizzard of Ozz,https://music.youtube.com/watch?v=hQ_Z-10dXSE&si=tvZKrXCizwE4aM01,anghi0m084,QR/anghi0m084.png
+Cross the Cross,Mantar,2016,Ode to the Flame,https://music.youtube.com/watch?v=8BuN_q4kegE&si=jlri8fwwtpeLbhlT,anghi0m085,QR/anghi0m085.png
+Crusader,Saxon,1984,Crusader,https://music.youtube.com/watch?v=OI5loEyhyZQ&si=UeVcUviglPRYDjXb,anghi0m086,QR/anghi0m086.png
+Crystal Mountain,Death,1995,Symbolic,https://music.youtube.com/watch?v=dRx2qP8yXuY&si=zjhqRTEUV-S7WnPH,anghi0m087,QR/anghi0m087.png
+Crystal Skull,Mastodon,2006,Capillarian Crest / Crystal Skull,https://music.youtube.com/watch?v=HWq7O7M6cbk&si=kSWBdgc6-MEkRJgr,anghi0m088,QR/anghi0m088.png
+Curl of the Burl,Mastodon,2011,The Hunter,https://music.youtube.com/watch?v=Gu9NcdOOQ3I&si=xVKeKOqDjxcztuRk,anghi0m089,QR/anghi0m089.png
+Dance Macabre,Ghost,2018,Prequelle,https://music.youtube.com/watch?v=tjjH8b3NA8c&si=xM5H2SpGT3zycRLY,anghi0m090,QR/anghi0m090.png
+Dancers to a Discordant System,Meshuggah,2008,obZen,https://music.youtube.com/watch?v=a1zFJKPOnXg&si=-pD8m8BH6b1USbXn,anghi0m091,QR/anghi0m091.png
+Davidian,Machine Head,1994,Burn My Eyes,https://music.youtube.com/watch?v=sM8Awen6umM&si=RRlKWedXjkdP0UOk,anghi0m092,QR/anghi0m092.png
+Day sixteen: looser ,Ayreon ,2004,The Human Equation,https://music.youtube.com/watch?v=68UB9Ib390I&si=sGWOtPo91Z8kNHaM,anghi0m093,QR/anghi0m093.png
+Dead Embryonic Cells,Sepultura,1991,Arise,https://music.youtube.com/watch?v=75rhSf6ORGg&si=4BVk8onQ5E1QhyKD,anghi0m094,QR/anghi0m094.png
+Dead Skin Mask,Slayer,1990,Seasons in the Abyss,https://music.youtube.com/watch?v=eVmaqj668Fk&si=KspOlToh0s9XHh85,anghi0m095,QR/anghi0m095.png
+Dein Anblick ,Schandmaul ,2002,Narrenkonig ,https://music.youtube.com/watch?v=MIydkUxnWGs&si=x9_yCiene3SdFLWq,anghi0m096,QR/anghi0m096.png
+Deliver Us,In Flames,2011,Sounds of a Playground Fading,https://music.youtube.com/watch?v=rd5Nfv_xxCc&si=NrAow5qTDvt-7z1M,anghi0m097,QR/anghi0m097.png
+Deliverance,Opeth,2002,Deliverance,https://music.youtube.com/watch?v=pWrg5aZKIa8&si=cWbfWnz4dChRhj4o,anghi0m098,QR/anghi0m098.png
+Demiurge,Meshuggah,2012,Koloss,https://music.youtube.com/watch?v=_dIUpRypJwo&si=tLZ_nQlDFlPcnXSW,anghi0m099,QR/anghi0m099.png
+Denim and Leather,Saxon,1981,Denim and Leather,https://music.youtube.com/watch?v=hFly5TwDKOg&si=kpa1uMDe3zXvqpR2,anghi0m100,QR/anghi0m100.png
+Der letzte Tag,Lacrimosa,1997,Stille,https://music.youtube.com/watch?v=Y0BsCUIU1JA&si=x1PpTV4JSaWrM2EF,anghi0m101,QR/anghi0m101.png
+Die baby die,Kadavar ,2017,Rough times ,https://music.youtube.com/watch?v=_4wGBQHH4-M&si=bQ5uNrNWp3jmGntF,anghi0m102,QR/anghi0m102.png
+Der Sturm,Equilibrium,2005,Turis Fratyr,https://music.youtube.com/watch?v=eO5JhU79-EU&si=WPSmxpFvlGPxUmjV,anghi0m103,QR/anghi0m103.png
+Diggy Diggy hole ,Wind Rose ,2019,Wintersaga,https://music.youtube.com/watch?v=0FvHyHaT8ys&si=OfrpP6ZJfv3vy1Xy,anghi0m104,QR/anghi0m104.png
+Digital world ,Amaranthe,2014,Massive Addictive,https://music.youtube.com/watch?v=uDUHDShsiRE&si=W--9d3AIrUGgvzFR,anghi0m105,QR/anghi0m105.png
+Domination,Pantera,1990,Cowboys from Hell,https://music.youtube.com/watch?v=mDATU5_jeC0&si=ykUySYcHyVQy5JN3,anghi0m106,QR/anghi0m106.png
+Doomed,Bring Me the Horizon,2015,That's the Spirit,https://music.youtube.com/watch?v=5Oc0ja19_GU&si=XsdjVYZTNAD1D1j3,anghi0m107,QR/anghi0m107.png
+Doomsday,Architects,2018,Holy Hell,https://music.youtube.com/watch?v=MNynO3MpNMg&si=XSsgcr9k2QePBFL4,anghi0m108,QR/anghi0m108.png
+Doomsday machine ,Kadavar ,2013,Abra kadavar ,https://music.youtube.com/watch?v=_aJerFidWqg&si=X-fcsEoEK1x63GBr,anghi0m109,QR/anghi0m109.png
+Down with the Sickness,Disturbed,2000,The Sickness,https://music.youtube.com/watch?v=JKmmGegan64&si=ZgYynb1-10jc6WsM,anghi0m110,QR/anghi0m110.png
+Downfall,Children of Bodom,1999,Hatebreeder,https://music.youtube.com/watch?v=qHP5SF5dXtE&si=ORsNfYwZ8kdbrBmn,anghi0m111,QR/anghi0m111.png
+Army of the Night,Powerwolf,2015,Blessed & Possessed,https://music.youtube.com/watch?v=4hshdNgEwTw&si=6LURvJ_sgrKapqLY,anghi0m112,QR/anghi0m112.png
+Dream House,Deafheaven,2013,Sunbather,https://music.youtube.com/watch?v=81ITd6ByRLE&si=4m8LO-UZPE3-P7B_,anghi0m113,QR/anghi0m113.png
+Drink ,Alestorm ,2014,Sunset on the Golden Age,https://music.youtube.com/watch?v=pibSHkDG91g&si=kx1VtWtGjBFklXMd,anghi0m114,QR/anghi0m114.png
+Du Hast,Rammstein,1997,Sehnsucht,https://music.youtube.com/watch?v=kiw_VxQ2oXo&si=ThQciBVu2oyYwsl4,anghi0m115,QR/anghi0m115.png
+Du nicht ,Knorkator ,2011,Es werde Nicht ,https://music.youtube.com/watch?v=EJ5DA-p6ayg&si=cgHGJkq-8bf9qknV,anghi0m116,QR/anghi0m116.png
+Duality,Slipknot,2004,Vol. 3: (The Subliminal Verses),https://music.youtube.com/watch?v=B2lmOei7qfk&si=QITfkmA6AhflM2D6,anghi0m117,QR/anghi0m117.png
+Dunkelheit,Burzum,1996,Filosofem,https://music.youtube.com/watch?v=-ZENtivAi6I&si=tkJl6k9U9pWqxhW9,anghi0m118,QR/anghi0m118.png
+Dying for an Angel ,Avantasia ,2010,The Wicked Symphony,https://music.youtube.com/watch?v=LkSRS1Bmg_0&si=mOtoy3cVNKLsWRYC,anghi0m119,QR/anghi0m119.png
+Dystopia,Megadeth,2016,Dystopia,https://music.youtube.com/watch?v=hvUyHMJs9LU&si=7Y2x1qCPtCq1w7jU,anghi0m120,QR/anghi0m120.png
+Eagle Fly Free,Helloween,1988,Keeper of the Seven Keys: Part II,https://music.youtube.com/watch?v=k3arMBjWC3Y&si=H3u1P0LG7WGDf6v2,anghi0m121,QR/anghi0m121.png
+Ein guter Tag zum Sterben ,J. B. O. ,1995,Explizite lyrics ,https://music.youtube.com/watch?v=MkR6yYDg9PM&si=-RMfhnjvST57XG9Z,anghi0m122,QR/anghi0m122.png
+Élan,Nightwish,2015,Endless Forms Most Beautiful,https://music.youtube.com/watch?v=-WsOaSUXRHE&si=rdSbPqIvHT_UTFTd,anghi0m123,QR/anghi0m123.png
+Electric Crown,Testament,1992,The Ritual,https://music.youtube.com/watch?v=7AvCwfuPoMQ&si=4Fty9ERJOJPL1cxR,anghi0m124,QR/anghi0m124.png
+Electric Eye,Judas Priest,1982,Screaming for Vengeance,https://music.youtube.com/watch?v=3dbRdzATXBE&si=z0N7j1en47fTkTs-,anghi0m125,QR/anghi0m125.png
+Endzeit,Heaven Shall Burn,2008,Iconoclast (Part 1: The Final Resistance),https://music.youtube.com/watch?v=dvNRLsKJv0E&si=19ZU6z7piF3UGW_9,anghi0m126,QR/anghi0m126.png
+Engel,Rammstein,1997,Sehnsucht,https://music.youtube.com/watch?v=jQjdEDWDeQ8&si=M4wFd8I3WwpMGOys,anghi0m127,QR/anghi0m127.png
+Enter sandman,Metallica,1991,Metallica (commonly known as the Black Album),https://music.youtube.com/watch?v=CHIWNDAwTqQ&si=Pb85Y5FFhSONBryw,anghi0m128,QR/anghi0m128.png
+Erdbeermund,Schandmaul,1995,MCMXCV,https://music.youtube.com/watch?v=Rxmpmtn89NU&si=2zbLhvxhI79e23lg,anghi0m129,QR/anghi0m129.png
+Everybody Dies ,Ayreon ,2017,The Source,https://music.youtube.com/watch?v=4SdddU4jrjI&si=joYCFpl7B3LdCnBW,anghi0m130,QR/anghi0m130.png
+Needled 24 / 7,Children of Bodom,2003,Hate Crew Deathroll,https://music.youtube.com/watch?v=0nx9WwMskgs&si=t7r4bNMR1NjKL0rN,anghi0m131,QR/anghi0m131.png
+Executioner’s Tax (Swing of the Axe),Power Trip,2017,Nightmare Logic,https://music.youtube.com/watch?v=ECRbEM9Mwcs&si=Mi6ZWyBYp0WtDgh9,anghi0m132,QR/anghi0m132.png
+Extreme Aggression,Kreator,1989,Extreme Aggression,https://music.youtube.com/watch?v=f82Z_71kXXE&si=W5PYwezll3KJ6sKr,anghi0m133,QR/anghi0m133.png
+Faint,Linkin Park,2003,Meteora,https://music.youtube.com/watch?v=2mXNRsyTitA&si=K9zKUwlRkYpwHR47,anghi0m134,QR/anghi0m134.png
+Farewell ,Avantasia ,2001,The Metal Opera,https://music.youtube.com/watch?v=3z4z5QLCvH8&si=6UgCVqBYF22_GdOK,anghi0m135,QR/anghi0m135.png
+Fear of the Dark,Iron Maiden,1992,Fear of the Dark,https://music.youtube.com/watch?v=bePCRKGUwAY&si=n3APHjANn4Ne06rr,anghi0m136,QR/anghi0m136.png
+Feuer frei!,Rammstein,2002,Mutter,https://music.youtube.com/watch?v=bUXoDvioAuE&si=vdjycpcA5Dq9hc7H,anghi0m137,QR/anghi0m137.png
+Everything,Crematory,2016,Monument ,https://music.youtube.com/watch?v=aUR7IDKNoWY&si=IoEdblUOEdC66Oxc,anghi0m138,QR/anghi0m138.png
+Flattening of Emotions,Death,1991,Human,https://music.youtube.com/watch?v=yuPoJgnGdcI&si=xbVBf88neyTfUg4N,anghi0m139,QR/anghi0m139.png
+Flying Whales,Gojira,2005,From Mars to Sirius,https://music.youtube.com/watch?v=eg_OyqkITSE&si=RUv_1rjeqTjfPXdA,anghi0m140,QR/anghi0m140.png
+For Whom the Bell Tolls,Metallica,1984,Ride the Lightning,https://music.youtube.com/watch?v=B_HSa1dEL9s&si=wBKUlmeIo-tZTYHA,anghi0m141,QR/anghi0m141.png
+Forever,Code Orange,2017,Forever,https://music.youtube.com/watch?v=XXpU9tg_Zpk&si=9IMRGsfrY8JAAYME,anghi0m142,QR/anghi0m142.png
+Fortitude,Gojira,2021,Fortitude,https://music.youtube.com/watch?v=5eROWINzcJ8&si=LCT9xOEI4RIMBwQ0,anghi0m143,QR/anghi0m143.png
+Freak on a Leash,Korn,1998,Follow the Leader,https://music.youtube.com/watch?v=ihgc5LQbjg8&si=kxbU0EEdz9bBH_85,anghi0m144,QR/anghi0m144.png
+Freezing Moon,Mayhem,1994,De Mysteriis Dom Sathanas,https://music.youtube.com/watch?v=9emO9qo4FwE&si=ksP9EiDarz7zPi39,anghi0m145,QR/anghi0m145.png
+From the Cradle to Enslave,Cradle of Filth,1999,From the Cradle to Enslave,https://music.youtube.com/watch?v=ktbxYNGjqbY&si=YenjpuCGwtgtWDLy,anghi0m146,QR/anghi0m146.png
+Future World,Helloween,1987,Keeper of the Seven Keys: Part I,https://music.youtube.com/watch?v=u7ozEjfhcN0&si=K9SEHcSZfLmft3v8,anghi0m147,QR/anghi0m147.png
+Ghost of Perdition,Opeth,2005,Ghost Reveries,https://music.youtube.com/watch?v=3NttJB0DfiQ&si=TTmpsxXhBBsAnZkY,anghi0m148,QR/anghi0m148.png
+Ghost Walking,Lamb of God,2012,Resolution,https://music.youtube.com/watch?v=7EU_OpzgBHI&si=cKV2BjHhXT9XZXmu,anghi0m149,QR/anghi0m149.png
+Gimme Chocolate!!,BABYMETAL,2014,BABYMETAL,https://music.youtube.com/watch?v=3OE09S9eJNU&si=fVpfcvKgr8cnFlFE,anghi0m150,QR/anghi0m150.png
+"Girls, Girls, Girls",Mötley Crüe,1987,"Girls, Girls, Girls",https://music.youtube.com/watch?v=XZU5XyqnuyM&si=cUWVl49yoSOGoM9O,anghi0m151,QR/anghi0m151.png
+Disciple,Slayer,2001,God Hates Us All,https://music.youtube.com/watch?v=6S-Wnmb0too&si=_KwLO_C8Z-Fmxgij,anghi0m152,QR/anghi0m152.png
+God of Thunder,KISS,1976,Destroyer,https://music.youtube.com/watch?v=MysFVQ7SMnE&si=QwIjt0hHH5Z-ldbU,anghi0m153,QR/anghi0m153.png
+Gothic,Paradise Lost,1991,Gothic,https://music.youtube.com/watch?v=TnqXkN1xpO8&si=S4HNTYy1Ih17Ljl3,anghi0m154,QR/anghi0m154.png
+The Green Manalishi (With the Two Pronged Crown),Judas Priest,1979,Hell Bent for Leather,https://music.youtube.com/watch?v=y-8jaQ6f1XE&si=CHROG4_KjJGXaZtm,anghi0m155,QR/anghi0m155.png
+Hail Destroyer,Cancer Bats,2008,Hail Destroyer,https://music.youtube.com/watch?v=ZRUZQEMXfJw&si=UskLNMlSphTPiMWL,anghi0m156,QR/anghi0m156.png
+Hail the Apocalypse,Avatar,2014,Hail the Apocalypse,https://music.youtube.com/watch?v=QCE_0o-kmp8&si=AHM4oAdGGM9Wch3A,anghi0m157,QR/anghi0m157.png
+Hair of the Dog,Nazareth,1975,Hair of the Dog,https://music.youtube.com/watch?v=cdm-Lbvv-cs&si=HG6phfvmEk6oVlrA,anghi0m158,QR/anghi0m158.png
+Hallowed Be Thy Name,Iron Maiden,1982,The Number of the Beast,https://music.youtube.com/watch?v=HAQQUDbuudY&si=AQCN6mvKxKlmbq6C,anghi0m159,QR/anghi0m159.png
+Hammer Smashed Face,Cannibal Corpse,1992,Tomb of the Mutilated,,anghi0m160,QR/anghi0m160.png
+Handshake with Hell ,Arch Enemy,2022,Deceivers,https://music.youtube.com/watch?v=Y2rGkgzqtEw&si=3wfC1BcpRQpc_LKM,anghi0m161,QR/anghi0m161.png
+Hangar 18,Megadeth,1990,Rust in Peace,https://music.youtube.com/watch?v=k_GFAt-5q2E&si=4yBFwSbYorGVFEQ6,anghi0m162,QR/anghi0m162.png
+Hate über alles,Kreator,2022,Hate über alles,https://music.youtube.com/watch?v=55uyqmWmls0&si=IDO4w8BxwjMuYAAF,anghi0m163,QR/anghi0m163.png
+Hearts Burst into Fire,Bullet for My Valentine,2008,Scream Aim Fire,https://music.youtube.com/watch?v=bAaRP2sCjyc&si=WKkZtAK4_rKmq_sR,anghi0m164,QR/anghi0m164.png
+Heartwork,Carcass,1993,Heartwork,https://music.youtube.com/watch?v=7XamOQN_gUQ&si=GFs53HNK4GbggdeH,anghi0m165,QR/anghi0m165.png
+Heaven and Hell,Black Sabbath,1980,Heaven and Hell,https://music.youtube.com/watch?v=RVUK2rtAkJE&si=b8a2KfTQnaLya6AU,anghi0m166,QR/anghi0m166.png
+Heaven can wait ,Gamma Ray ,1990,Heading for Tomorrow,https://music.youtube.com/watch?v=OOWakf4hc9k&si=kJVsaGgi7rIS6Aaz,anghi0m167,QR/anghi0m167.png
+Heavy Metal Breakdown,Grave Digger,1984,Heavy Metal Breakdown,https://music.youtube.com/watch?v=aJgs6-6dxFA&si=Im_WQMimNpznQ3Wo,anghi0m168,QR/anghi0m168.png
+Helter skelter,The Beatles,1968,The White Album,https://music.youtube.com/watch?v=vWW2SzoAXMo&si=N-1ttOLuT5uS1nxT,anghi0m169,QR/anghi0m169.png
+Her Ghost in the Fog,Cradle of Filth,2000,Midian,https://music.youtube.com/watch?v=QY8_nKejW-c&si=ffdMmi8D2vElp7SS,anghi0m170,QR/anghi0m170.png
+Herr Mannelig,Haggard,2004,Eppur Si Muove,https://music.youtube.com/watch?v=Q2FvEb59lQY&si=OaR7--Uq_kyAsFP7,anghi0m171,QR/anghi0m171.png
+Highway Star,Deep Purple,1972,Machine Head,https://music.youtube.com/watch?v=_hJEyDOn6Ho&si=iylToUtnhLY8iJ8c,anghi0m172,QR/anghi0m172.png
+Hisingen blues ,Graveyard ,2011,Hisingen blues ,https://music.youtube.com/watch?v=1w61xmQgukg&si=_DBR1DeUoY6loe86,anghi0m173,QR/anghi0m173.png
+Holy Diver,Dio,1983,Holy Diver,https://music.youtube.com/watch?v=uDtgnYZsw7A&si=hzV67A-7CmarM7o5,anghi0m174,QR/anghi0m174.png
+Holy Roller,Spiritbox,2021,Eternal Blue,https://music.youtube.com/watch?v=F_t06tUFI_A&si=aHnYc4zfVK5fbsnj,anghi0m175,QR/anghi0m175.png
+Holy Wars... The Punishment Due,Megadeth,1990,Rust in Peace,https://music.youtube.com/watch?v=LOXrjUuXEn0&si=SAK7E-WowwnmHG5R,anghi0m176,QR/anghi0m176.png
+Hunter’s Moon,Ghost,2021,"IMPERA
+ ",https://music.youtube.com/watch?v=mfjfZrghj4I&si=poQBzdVnE_4kbp2j,anghi0m177,QR/anghi0m177.png
+Hysteria,Muse,2003,Absolution,https://music.youtube.com/watch?v=HqAMbWjs5jY&si=o01dmmrGXa5gK-fc,anghi0m178,QR/anghi0m178.png
+I Am the Black Wizards,Emperor,1994,In the Nightside Eclipse,https://music.youtube.com/watch?v=egVLdD3sOqw&si=EuK9a7OjpE_xD58D,anghi0m179,QR/anghi0m179.png
+I Am the Law,Anthrax,1986,Among the Living,https://music.youtube.com/watch?v=i_Pga70f_YQ&si=7RXiiBffeqpmxfBA,anghi0m180,QR/anghi0m180.png
+I can see for miles,The Who,1967,The Who Sell Out,https://music.youtube.com/watch?v=ByxL7cQKB4Q&si=y-TIiIUtmIIJW3ow,anghi0m181,QR/anghi0m181.png
+I Cum Blood,Cannibal Corpse,1992,Tomb of the Mutilated,,anghi0m182,QR/anghi0m182.png
+I Don't Wanna Stop,Ozzy Osbourne,2007,Black Rain,https://music.youtube.com/watch?v=2nX6qGeyaGM&si=NCK1nSuHLSOPJlVU,anghi0m183,QR/anghi0m183.png
+I Want Out,Helloween,1988,Keeper of the Seven Keys: Part II,https://music.youtube.com/watch?v=H7-pFa8KHAU&si=vOpISw0CT1ldA6Jc,anghi0m184,QR/anghi0m184.png
+I Will Be Heard,Hatebreed,2002,Perseverance,https://music.youtube.com/watch?v=g2aQOYR_HI4&si=cP4tDpe--O3DLwt_,anghi0m185,QR/anghi0m185.png
+I will be king ,Kissin dynamite ,2012,"Money, sex and power ",https://music.youtube.com/watch?v=sj7oC556PUg&si=t_qtJKoKBNowNOUm,anghi0m186,QR/anghi0m186.png
+Ich sag' JBO,J. B. O. ,2000,Sex sex sex,https://music.youtube.com/watch?v=PuNQFVTNn2I&si=K3-8ZfV5KP3AV0Nk,anghi0m187,QR/anghi0m187.png
+Ich Will,Rammstein,2001,Mutter,https://music.youtube.com/watch?v=6BkbHk0iKZc&si=illOKMYVb28DKPl8,anghi0m188,QR/anghi0m188.png
+If I die in battle ,Van canto ,2011,Break the Silence,https://music.youtube.com/watch?v=Snv5VsNSv-s&si=tCoeeq7GTIcMdZ9h,anghi0m189,QR/anghi0m189.png
+Immigrant Song,Led Zeppelin,1970,Led Zeppelin III,https://music.youtube.com/watch?v=5eHkjPCGXKQ&si=A8Jn64cmVFer2P3N,anghi0m190,QR/anghi0m190.png
+In a gada da Vida,Iron butterfly,1968,In-A-Gadda-Da-Vida,https://music.youtube.com/watch?v=Tfpn3wHoNGA&si=mSRF99f0jUZhOBFv,anghi0m191,QR/anghi0m191.png
+In Due Time,Killswitch Engage,2013,Disarm the Descent,https://music.youtube.com/watch?v=tOVRd-qjiJg&si=9eRWpzdhvjSkkVZX,anghi0m192,QR/anghi0m192.png
+In the Court of the Dragon,Trivium,2021,In the Court of the Dragon,https://music.youtube.com/watch?v=zCyOZcoZ2iE&si=oHPJFb_bAP-tA57Y,anghi0m193,QR/anghi0m193.png
+In Waves,Trivium,2011,In Waves,https://music.youtube.com/watch?v=tX1MHYIZ0As&si=XJoXnZ4cylzFyQZV,anghi0m194,QR/anghi0m194.png
+Indestructible,Disturbed,2008,Indestructible,https://music.youtube.com/watch?v=kjRWG0tKD4A&si=YO4EMYdDOuhmMKdc,anghi0m195,QR/anghi0m195.png
+Wildfire,Periphery,2023,Periphery V: Djent Is Not a Genre,https://music.youtube.com/watch?v=325JyKvu-HE&si=X-b9Y_On6iu-kr6r,anghi0m196,QR/anghi0m196.png
+Inner Self,Sepultura,1989,Beneath the Remains,https://music.youtube.com/watch?v=dQZ7QerXE2k&si=tCio1tr02e7XCCDI,anghi0m197,QR/anghi0m197.png
+Into the Infinity of Thoughts,Emperor,1994,In the Nightside Eclipse,https://music.youtube.com/watch?v=N-Ac4ARy-sE&si=06Wv_8j7SSwJQHiI,anghi0m198,QR/anghi0m198.png
+Into the Void,Black Sabbath,1971,Master of Reality,https://music.youtube.com/watch?v=-R5XnrZn47Q&si=aTPeDhSL6k_0FxJO,anghi0m199,QR/anghi0m199.png
+Invasion,Haken,2022,Virus,https://music.youtube.com/watch?v=KZEFBi0nkfY&si=m2FDNyL86honW6Ps,anghi0m200,QR/anghi0m200.png
+Iron ,Ensiferum ,2004,Iron ,https://music.youtube.com/watch?v=IYq4AePD72M&si=Vi6R4UzIaNw5NPJG,anghi0m201,QR/anghi0m201.png
+Iron Man,Black Sabbath,1970,Paranoid,https://music.youtube.com/watch?v=b3-QqGVt-tM&si=brc2W9H72EPJtdX4,anghi0m202,QR/anghi0m202.png
+Ironbound,Overkill,2010,Ironbound,https://music.youtube.com/watch?v=27aBHt5oE9w&si=diFN3rD6l9rPa0Nn,anghi0m203,QR/anghi0m203.png
+Julia und die Räuber ,Subway to Sally ,1996,Foppt den Dämon ,https://music.youtube.com/watch?v=GHa2cmXeANk&si=PSAmiK0BMpGgoVH5,anghi0m204,QR/anghi0m204.png
+Zwischen uns,Eisbrecher,2015,Schock,https://music.youtube.com/watch?v=AF5BRH4-VoY&si=nOyonN8IbUklM0yx,anghi0m205,QR/anghi0m205.png
+Karate,BABYMETAL,2016,METAL RESISTANCE,https://music.youtube.com/watch?v=L92Yj-mQ-ew&si=oRUVOBRXZWkzop3D,anghi0m206,QR/anghi0m206.png
+Undestructable Power Of Darkness,Mystic Circle,1999,Infernal Satanic Verses,https://music.youtube.com/watch?v=mdFE01AV5-A&si=qnSex2e5AZnxisiF,anghi0m207,QR/anghi0m207.png
+Keelhauled,Alestorm ,2009,Black Sails Over Europe,https://music.youtube.com/watch?v=HBeCXN1kyNI&si=boiyoYGfFKhYOHUg,anghi0m208,QR/anghi0m208.png
+Keeper of the Seven Keys,Helloween,1988,Keeper of the Seven Keys: Part II,https://music.youtube.com/watch?v=iDpAahKUNB4&si=2gqUzsSlwWDlilGY,anghi0m209,QR/anghi0m209.png
+Kickstart My Heart,Mötley Crüe,1989,Dr. Feelgood,https://music.youtube.com/watch?v=e17mr5ZtWPI&si=btgS7M3hGo5ABuSO,anghi0m210,QR/anghi0m210.png
+Kill the King,Rainbow,1977,Long Live Rock 'n' Roll,https://music.youtube.com/watch?v=OhfvzxYXlBU&si=qSJ9UB2tQcHU0C1T,anghi0m211,QR/anghi0m211.png
+Killing in the Name,Rage Against the Machine,1992,Rage Against the Machine,https://music.youtube.com/watch?v=2o9aoL0NWpw&si=C91jKziK68pyY28Q,anghi0m212,QR/anghi0m212.png
+King,Tesseract,2018,Sonder,https://music.youtube.com/watch?v=rrL-gJM2n1U&si=QTPDhhkaiB-HYdF0,anghi0m213,QR/anghi0m213.png
+Kleid aus Rosen,Subway To Sally,2001,Herzblut,https://music.youtube.com/watch?v=VjoPvhdpnGk&si=oywkFbelRCGOflwX,anghi0m214,QR/anghi0m214.png
+My Mother Told Me,Saltatio Mortis,2021,Für immer frei,https://music.youtube.com/watch?v=iq6ZyHezloE&si=xrNk8PSKmfCj4C0G,anghi0m215,QR/anghi0m215.png
+L’Enfant Sauvage,Gojira,2012,L’Enfant Sauvage,https://music.youtube.com/watch?v=tdVjuS_FhI4&si=inz69xfBILfFj-R1,anghi0m216,QR/anghi0m216.png
+Let me be a shadow ,Kadavar ,2025,I just want to be a sound ,https://music.youtube.com/watch?v=lCfjTMrajqk&si=RSFrZ_eHjuveLm-1,anghi0m217,QR/anghi0m217.png
+Lights Out,UFO,1977,Lights Out,https://music.youtube.com/watch?v=VQqU03FGH-Y&si=cDqiPFSj60l8EsdN,anghi0m218,QR/anghi0m218.png
+Live for This,Hatebreed,2003,The Rise of Brutality,https://music.youtube.com/watch?v=qmjf6SjrvRY&si=QnF8HCFerA7mqkh0,anghi0m219,QR/anghi0m219.png
+Long Live Rock 'n' Roll,Rainbow,1978,Long Live Rock 'n' Roll,https://music.youtube.com/watch?v=u4lxo7Ia_rY&si=67WSUFWsmClg8lBT,anghi0m220,QR/anghi0m220.png
+Looks That Kill,Mötley Crüe,1983,Shout at the Devil,https://music.youtube.com/watch?v=_v_Ae1gdHGQ&si=Dc6BslnXfkzyoprw,anghi0m221,QR/anghi0m221.png
+Mad Butcher,Destruction,1984,Sentence of Death,https://music.youtube.com/watch?v=y5xMp8PkPdM&si=Q_54zdbtHMSdyUpe,anghi0m222,QR/anghi0m222.png
+Madhouse,Anthrax,1985,Spreading the Disease,https://music.youtube.com/watch?v=C9zZEqFCjk4&si=-_Z8Ns4Di9k6EpGO,anghi0m223,QR/anghi0m223.png
+Man on the Silver Mountain,Rainbow,1975,Ritchie Blackmore's Rainbow,https://music.youtube.com/watch?v=ORnvO1VyYMk&si=GXRAKkZFfks_LfP7,anghi0m224,QR/anghi0m224.png
+Marigold,Periphery,2016,Periphery III: Select Difficulty,https://music.youtube.com/watch?v=2smB0p8P-GQ&si=ziaAJwLxorl4jRme,anghi0m225,QR/anghi0m225.png
+Master of Puppets,Metallica,1986,Master of Puppets,https://music.youtube.com/watch?v=E0ozmU9cJDg&si=Deqs_QNhuttVK6XY,anghi0m226,QR/anghi0m226.png
+Mein Teil,Rammstein,2004,"Reise, Reise",https://music.youtube.com/watch?v=ITcj8mePex0&si=etEg7D2HOxOeKfue,anghi0m227,QR/anghi0m227.png
+Kleid aus Rosen,Subway to Sally,2001,"Herzblut
+ ",https://music.youtube.com/watch?v=VjoPvhdpnGk&si=7SC6TuY306ozcmXj,anghi0m228,QR/anghi0m228.png
+Merlin's will,Ayreon ,1995,The Final Experiment,https://music.youtube.com/watch?v=We8iDzzhM2E&si=123kqOmAfToxnsgA,anghi0m229,QR/anghi0m229.png
+METALI!! (feat. Tom Morello),BABYMETAL,2024,Metal Forth,https://music.youtube.com/watch?v=s9bQkfr1qZo&si=zzD-GO8x_FolvjiV,anghi0m230,QR/anghi0m230.png
+Meteor,Architects,2021,For Those That Wish to Exist,https://music.youtube.com/watch?v=FTiWnWt_Tks&si=LETZ-lLMsgU9pyBD,anghi0m231,QR/anghi0m231.png
+Mirror Mirror,Blind Guardian,1998,Nightfall in Middle-Earth,https://music.youtube.com/watch?v=CNGCvI9dpZY&si=eCUlIlP26ERhFtMq,anghi0m232,QR/anghi0m232.png
+Mother North,Satyricon,1996,Nemesis Divina,https://music.youtube.com/watch?v=soWZROHVvmE&si=6u_hlpIl3yPh1S0Q,anghi0m233,QR/anghi0m233.png
+Mourning Palace,Dimmu Borgir,1997,Enthrone Darkness Triumphant,https://music.youtube.com/watch?v=U9pLV9kG3-s&si=9oKAadeikrN9B_me,anghi0m234,QR/anghi0m234.png
+My Curse,Killswitch Engage,2006,As Daylight Dies,https://music.youtube.com/watch?v=B4vTwppAfDg&si=SA1T4vbPXC61B9Wz,anghi0m235,QR/anghi0m235.png
+My Monster ,Kissin dynamite ,2024,Back with a bang ,https://music.youtube.com/watch?v=0jHHuPWP--Y&si=FvaDvrqrynp4oR-X,anghi0m236,QR/anghi0m236.png
+My Own Summer (Shove It),Deftones,1997,Around the Fur,https://music.youtube.com/watch?v=PIF4So6xcU8&si=wYjjShVGCWdi4dIK,anghi0m237,QR/anghi0m237.png
+My Own Coffin,Soul Demise,2005,Blind,https://music.youtube.com/watch?v=_xNAsuhUVQU&si=SIMipfNETXI2HioM,anghi0m238,QR/anghi0m238.png
+Nemesis,Arch Enemy,2005,Doomsday Machine,https://music.youtube.com/watch?v=O4N-J2GngZo&si=YvYsMNpvKlD55MIP,anghi0m239,QR/anghi0m239.png
+Nemo,Nightwish,2004,Once,https://music.youtube.com/watch?v=dw1yftNZf2s&si=2MQHbAeJTRnglLLb,anghi0m240,QR/anghi0m240.png
+Neon Knights,Black Sabbath,1980,Heaven and Hell,https://music.youtube.com/watch?v=FKlz83CZ3I4&si=rNjUC5cHQhw7P7GL,anghi0m241,QR/anghi0m241.png
+New Millennium Cyanide Christ,Meshuggah,1998,Chaosphere,https://music.youtube.com/watch?v=hugxf_jckTI&si=wkeoiFUMoGWKgsx4,anghi0m242,QR/anghi0m242.png
+Nightfall,Blind Guardian,1998,Nightfall in Middle-Earth,https://music.youtube.com/watch?v=M0TcB5lxfuY&si=WYOjddb_A96c4ci8,anghi0m243,QR/anghi0m243.png
+Nightmare,Avenged Sevenfold,2010,Nightmare,https://music.youtube.com/watch?v=KAljnUezZFk&si=DvZBxKV1v1dq5hv8,anghi0m244,QR/anghi0m244.png
+Nihilist,Architects,2016,All Our Gods Have Abandoned Us,https://music.youtube.com/watch?v=7N-fVpOXqlg&si=ABdmh9the7LAWa6R,anghi0m245,QR/anghi0m245.png
+No Place for Disgrace,Flotsam and Jetsam,1990,No Place for Disgrace,https://music.youtube.com/watch?v=awy9_08Pj_8&si=RyHuNKMpXMoUC4u6,anghi0m246,QR/anghi0m246.png
+Nocturne,Tesseract,2013,Altered State,https://music.youtube.com/watch?v=Z9_vh_PWPWo&si=JU6UFL1v8dQVtcd5,anghi0m247,QR/anghi0m247.png
+Merlin,Flowing Tears,2002,Serpentine,https://music.youtube.com/watch?v=FMjpeFNAjp8&si=nzJ6rSNBRCsohQW5,anghi0m248,QR/anghi0m248.png
+Not the end of the road ,Kissin dynamite ,2022,Not the end of the road ,https://music.youtube.com/watch?v=Lr9m96o-DrU&si=3a-BIN3f_sX4Puih,anghi0m249,QR/anghi0m249.png
+Now You've Got Something to Die For,Lamb of God,2004,Ashes of the Wake,https://music.youtube.com/watch?v=Am7ueQ5WE3o&si=9neogYTVaNxJSflc,anghi0m250,QR/anghi0m250.png
+Nymphetamine Fix,Cradle of Filth,2004,Nymphetamine,https://music.youtube.com/watch?v=JW5vsXIezvI&si=kmhjRVY-ltNBKvMi,anghi0m251,QR/anghi0m251.png
+Oblivion,Mastodon,2009,Crack the Skye,https://music.youtube.com/watch?v=amagrxXDBdk&si=5L5YKqCJ5PZs53-p,anghi0m252,QR/anghi0m252.png
+One,Metallica,1988,...And Justice for All,https://music.youtube.com/watch?v=tlO3lZhDukU&si=RslpuTbtNjvWdKR7,anghi0m253,QR/anghi0m253.png
+Numb,Linkin Park,2003,Meteora,https://music.youtube.com/watch?v=5qZQEq_C3vc&si=UXyWH6g1KNPES1Og,anghi0m254,QR/anghi0m254.png
+Only,Anthrax,1993,Sound of White Noise,https://music.youtube.com/watch?v=qg5fpPbhms4&si=SWOgiYsjey08djlV,anghi0m255,QR/anghi0m255.png
+Over the Wall,Testament,1987,The Legacy,https://music.youtube.com/watch?v=1ecg459tS2Y&si=eem4k0JUCML1WiIJ,anghi0m256,QR/anghi0m256.png
+Overkill,Motörhead,1979,Overkill,https://music.youtube.com/watch?v=e-Fd1Cg5Nx4&si=WsAWKmNCXGSMAABG,anghi0m257,QR/anghi0m257.png
+Painkiller,Judas Priest,1990,Painkiller,https://music.youtube.com/watch?v=4s1gBIVOTtk&si=9jgCT65-Y0ON09cK,anghi0m258,QR/anghi0m258.png
+Panzer Division Marduk,Marduk,1999,Panzer Division,https://music.youtube.com/watch?v=sDNdtU_wc74&si=2y-wdWZAhwgyiAT3,anghi0m259,QR/anghi0m259.png
+Paranoid,Black Sabbath,1970,Paranoid,https://music.youtube.com/watch?v=m7nwbJLO9qo&si=SiIrqB01fYzgLIpo,anghi0m260,QR/anghi0m260.png
+Parasite Eve,Bring Me the Horizon,2020,Post Human: Survival Horror,https://music.youtube.com/watch?v=GbiB9BBs_qk&si=pA-JriogE3CuYlaT,anghi0m261,QR/anghi0m261.png
+Peace Sells,Megadeth,1986,Peace Sells... but Who's Buying?,https://music.youtube.com/watch?v=QquQkSNHdes&si=UZeVGn7tg7r0qM_R,anghi0m262,QR/anghi0m262.png
+Phobia,Kreator,1997,Outcast,https://music.youtube.com/watch?v=2dce5kDZEMk&si=lmMjS1xhgXNT10Mk,anghi0m263,QR/anghi0m263.png
+Plastic thunder,Bitter creek,1967,Plastic Thunder,https://music.youtube.com/watch?v=6HV5nH2eHFc&si=Wd1CUhnTits-jCFJ,anghi0m264,QR/anghi0m264.png
+Pleasure to Kill,Kreator,1986,Pleasure to Kill,https://music.youtube.com/watch?v=y3ppDTQrpmE&si=r62jdAyifxnMrV9s,anghi0m265,QR/anghi0m265.png
+Pommesgabel,Heavysaurus,2024,Pommesgabel,https://music.youtube.com/watch?v=qF_WsjkLnQY&si=8JQDiSEx0R0818XB,anghi0m266,QR/anghi0m266.png
+Power Train,Majestica,2025,Power Train,https://music.youtube.com/watch?v=TS6RU2RNZIU&si=KjtJcAq85d7WYO-c,anghi0m267,QR/anghi0m267.png
+Practice What You Preach,Testament,1989,Practice What You Preach,https://music.youtube.com/watch?v=uXYnzhVuJUI&si=QqmM9b5t9nl2qFbs,anghi0m268,QR/anghi0m268.png
+Princess of the Night,Saxon,1981,Denim and Leather,https://music.youtube.com/watch?v=fnzQISf8us4&si=FpmoY-mCjVZ0OOj1,anghi0m269,QR/anghi0m269.png
+Progenies of the Great Apocalypse,Dimmu Borgir,2003,Death Cult Armageddon,https://music.youtube.com/watch?v=8uC0dqxZmcY&si=ho0dBaajwUgIQxSS,anghi0m270,QR/anghi0m270.png
+Pull Harder on the Strings of Your Martyr,Trivium,2005,Ascendancy,https://music.youtube.com/watch?v=Kth4GrlRK6E&si=Ns8rYPD7KAm6r6mg,anghi0m271,QR/anghi0m271.png
+Pull Me Under,Dream Theater,1992,Images and Words,https://music.youtube.com/watch?v=cHqi2hoAXYQ&si=JYuCgI4Dn3hS5qJI,anghi0m272,QR/anghi0m272.png
+Puritania,Dimmu Borgir,2001,Puritanical Euphoric Misanthropia,https://music.youtube.com/watch?v=Klo_kwWTknQ&si=-AgSgnd5fRIVA6BL,anghi0m273,QR/anghi0m273.png
+Pushing the Tides,Mastodon,2021,Hushed and Grim,https://music.youtube.com/watch?v=Qz2wEWTImSs&si=BaSVdlHnMlHgNs-C,anghi0m274,QR/anghi0m274.png
+Rainbow in the Dark,Dio,1983,Holy Diver,https://music.youtube.com/watch?v=7XyHOdMvHg0&si=YCqA0iwEjcAlGCQm,anghi0m275,QR/anghi0m275.png
+Raining Blood,Slayer,1986,Reign in Blood,https://music.youtube.com/watch?v=Gy3BOmvLf2w&si=MqzsRBF7WYJ747JB,anghi0m276,QR/anghi0m276.png
+Raise Your Horns,Amon Amarth,2016,Jomsviking,https://music.youtube.com/watch?v=bGfgf-AmXfw&si=FgzGiXyvnQAY-HcF,anghi0m277,QR/anghi0m277.png
+Rap-Sody,Nanowar of Steel,2010,Into Gay Pride Ride,https://music.youtube.com/watch?v=JFjl4QQO2zY&si=qPHdxvCrtObxlSyf,anghi0m278,QR/anghi0m278.png
+Ratamahatta,Sepultura,1996,Roots,https://music.youtube.com/watch?v=LjlHWLUmvT0&si=nC-hoDsCMdPmnE8J,anghi0m279,QR/anghi0m279.png
+Ravenous,Arch Enemy,2001,Wages of Sin,https://music.youtube.com/watch?v=JSWC4c3LMhU&si=JiLRmhKjPtKaWT9R,anghi0m280,QR/anghi0m280.png
+Rebellion (The Clans Are Marching),Grave Digger,1996,Tunes of War,https://music.youtube.com/watch?v=Ns1K33XnH9g&si=VTVowGfLCOPFiCM8,anghi0m281,QR/anghi0m281.png
+Replica,Fear Factory,1995,Demanufacture,https://music.youtube.com/watch?v=qwntyr0j8MM&si=ldgbEvssf18AV02S,anghi0m282,QR/anghi0m282.png
+Rapunzel,Letzte Instanz,1999,Das Spiel,https://music.youtube.com/watch?v=5jHWkCL-yBA&si=Q44mdddKeMYLBzZu,anghi0m283,QR/anghi0m283.png
+Only for the Weak,In Flames,2000,Clayman,https://music.youtube.com/watch?v=q86owGQzaG0&si=MquBB6tv60ObK14F,anghi0m284,QR/anghi0m284.png
+Resurrection by Erection,Powerwolf,2009,Bible of the Beast,https://music.youtube.com/watch?v=HfVfnXtlzsk&si=LG2zIt7ntjAAR3tY,anghi0m285,QR/anghi0m285.png
+Riding the Storm,Running Wild,1989,Death or Glory,https://music.youtube.com/watch?v=klbaF9SPyBk&si=pApZPGgmEev_x_sq,anghi0m286,QR/anghi0m286.png
+Rock and Stone,Wind Rose ,2024,Trollslayer,https://music.youtube.com/watch?v=ZGV9ZB6f8dM&si=Nby0iZDjdEh_LXq7,anghi0m287,QR/anghi0m287.png
+Rock You Like a Hurricane,Scorpions,1984,Love at First Sting,https://music.youtube.com/watch?v=KpSGd-5c27s&si=jCnhvVSJjjSzXXVs,anghi0m288,QR/anghi0m288.png
+Roots,In This Moment,2017,Ritual,https://music.youtube.com/watch?v=PeOKsBAbAFg&si=7eTeoDz6Sv6AY7wi,anghi0m289,QR/anghi0m289.png
+Roots Bloody Roots,Sepultura,1996,Roots,https://music.youtube.com/watch?v=KuMlv7hmrFg&si=wbquD5W1Ldk4WXTR,anghi0m290,QR/anghi0m290.png
+Run to the Hills,Iron Maiden,1982,The Number of the Beast,https://music.youtube.com/watch?v=Q_XJ-7jNqws&si=jnLjmPJsUlaPRUIN,anghi0m291,QR/anghi0m291.png
+Sabbath Bloody Sabbath,Black Sabbath,1973,Sabbath Bloody Sabbath,https://music.youtube.com/watch?v=cYZE4vKDqzs&si=lk1OiqTVBeP9SNdC,anghi0m292,QR/anghi0m292.png
+Sad But True,Metallica,1991,Metallica (commonly known as the Black Album),https://music.youtube.com/watch?v=Gfikhqr-M84&si=usVut6As8_7huLmX,anghi0m293,QR/anghi0m293.png
+Sanctified with Dynamite,Powerwolf,2011,Blood of the Saints,https://music.youtube.com/watch?v=_RalKhxRBC8&si=_sI6rvS-RNreVjQu,anghi0m294,QR/anghi0m294.png
+Sängerkrieg,In Extremo,2008,Sängerkrieg,https://music.youtube.com/watch?v=OJGz9_QLf80&si=hMVSngwCENNpzfia,anghi0m295,QR/anghi0m295.png
+Scarlet,Periphery,2012,Periphery II: This Time It's Personal,https://music.youtube.com/watch?v=ijgfaiUJI5Y&si=rdysTTtx-gBcUoKI,anghi0m296,QR/anghi0m296.png
+Auf Kiel,Subway to Sally,2007,Bastard,https://music.youtube.com/watch?v=aBw7dPfYL-8&si=1FbMx09qITgwlPP5,anghi0m297,QR/anghi0m297.png
+Schwarz blüht der Enzian,Heino,2014,Schwarz blüht der Enzian,https://music.youtube.com/watch?v=kCuWBskp-a0&si=HSZ_rHILw4zyHDKD,anghi0m298,QR/anghi0m298.png
+5.März,Megaherz,2008,Mann Von Welt,https://music.youtube.com/watch?v=9EHHNfHSaBo&si=ZJS2_f8tYvHqW1H0,anghi0m299,QR/anghi0m299.png
+Seasons in the Abyss,Slayer,1990,Seasons in the Abyss,https://music.youtube.com/watch?v=hVJ4rYjUgX4&si=W4KT1iCjOAcx08Ct,anghi0m300,QR/anghi0m300.png
+Seek & Destroy,Metallica,1983,Kill 'Em All,https://music.youtube.com/watch?v=FLTchCiC0T0&si=CrGr9wzrV5rML53Z,anghi0m301,QR/anghi0m301.png
+Send Me a Sign,Gamma Ray,1999,Power Plant,https://music.youtube.com/watch?v=09P9AhzEUns&si=xeo7n6dRjZjcof5X,anghi0m302,QR/anghi0m302.png
+Set to Fail,Lamb of God,2009,Wrath,https://music.youtube.com/watch?v=7WunCTKJ238&si=UY7Q8Y9wubV9nKbw,anghi0m303,QR/anghi0m303.png
+Shadow Moses,Bring Me the Horizon,2013,Sempiternal,https://music.youtube.com/watch?v=VXuohkmlupA&si=lREMdlaAznR52UN-,anghi0m304,QR/anghi0m304.png
+Shock,Fear Factory,1998,Obsolete,https://music.youtube.com/watch?v=Ryw-lEyeQmY&si=uWnjpkSIgMJmLw3K,anghi0m305,QR/anghi0m305.png
+Shock Me,Baroness,2015,Purple,https://music.youtube.com/watch?v=VmztEA25CEs&si=C6RTjh8X83EtiIMa,anghi0m306,QR/anghi0m306.png
+Shockwave,Black Tide,2008,Light from Above,https://music.youtube.com/watch?v=AOy_TGF7JTw&si=YP1MHqVsY9xPpZ7V,anghi0m307,QR/anghi0m307.png
+Shout at the Devil,Mötley Crüe,1983,Shout at the Devil,https://music.youtube.com/watch?v=ztYWE_Ns4d8&si=9fho5X-J0gk8cjJ2,anghi0m308,QR/anghi0m308.png
+Show Yourself,Mastodon,2017,Emperor of Sand,https://music.youtube.com/watch?v=0hYBlq5a2yg&si=JR1KYGEjlwJ06Krs,anghi0m309,QR/anghi0m309.png
+Sieben ,Subway to Sally ,2005,Nord Nord Ost ,https://music.youtube.com/watch?v=ioKVrH97tG4&si=c0Ijsnj2fi-owV9f,anghi0m310,QR/anghi0m310.png
+Silence Speaks (feat. Oli Sykes),While She Sleeps,2017,You Are We,https://music.youtube.com/watch?v=9fx0w9NlOh8&si=BTRLu6f3fqruGk6x,anghi0m311,QR/anghi0m311.png
+Smoke on the Water,Deep Purple,1972,Machine Head,https://music.youtube.com/watch?v=1L3XxUxEb6U&si=nYW7QZrnIRVHSbFz,anghi0m312,QR/anghi0m312.png
+Smoking in the boys room,Mötley crüe,1985,Theatre of Pain,https://music.youtube.com/watch?v=LMBqnAYxR8M&si=ckdZyS5FSXmBIZMC,anghi0m313,QR/anghi0m313.png
+Snuff,Slipknot,2008,All Hope Is Gone,https://music.youtube.com/watch?v=Yi0YbsT0TJ0&si=9rFsv8e81oFlj6Zx,anghi0m314,QR/anghi0m314.png
+Sonne,Rammstein,2001,Mutter,https://music.youtube.com/watch?v=KUZ7jG7BKE8&si=GlX3TCnfJsf7vzAe,anghi0m315,QR/anghi0m315.png
+South of Heaven,Slayer,1988,South of Heaven,https://music.youtube.com/watch?v=74nTzbgDGWM&si=x4gin1o5yKbNcLwz,anghi0m316,QR/anghi0m316.png
+Speed King,Deep Purple,1970,Deep Purple in Rock,https://music.youtube.com/watch?v=_XO3QmYfdrI&si=DiTGJmvnELw63BTe,anghi0m317,QR/anghi0m317.png
+Spielmannsschwur,Saltatio Mortis,2007,Aus Der Asche,https://music.youtube.com/watch?v=2f2_erbUyY4&si=jEWV1mnrTMrPDbvn,anghi0m318,QR/anghi0m318.png
+Spillways,Ghost,2022,"IMPERA
+ ",https://music.youtube.com/watch?v=iVWeky0WPbU&si=x9XhXDwGYib_47cd,anghi0m319,QR/anghi0m319.png
+Spit It Out,Slipknot,1999,Slipknot,https://music.youtube.com/watch?v=pH4PkaN3eVA&si=Mvvds5OHjiym-eO4,anghi0m320,QR/anghi0m320.png
+Square Hammer,Ghost,2016,Popestar,https://music.youtube.com/watch?v=M6n0XBJqLfM&si=jPI1mzQ8bd8fUY33,anghi0m321,QR/anghi0m321.png
+Stallions of the Highway,Saxon,1979,Saxon,https://music.youtube.com/watch?v=7udhm_LwXS8&si=7mwWJCjkMbc1zE0g,anghi0m322,QR/anghi0m322.png
+Stargazer,Rainbow,1976,Rising,https://music.youtube.com/watch?v=YmJIccPWnEk&si=cQF8DGoQavpktyVp,anghi0m323,QR/anghi0m323.png
+Starlight,Muse,2006,Black Holes and Revelations,https://music.youtube.com/watch?v=2G9_5ZQYXVY&si=4Dg3cDcDlvMlBEI8,anghi0m324,QR/anghi0m324.png
+Steel Commanders (feat. Tina Guo),Sabaton,2021,Single (World of Tanks Collab),https://music.youtube.com/watch?v=JqdkfDDKmoM&si=sADQVPPvAkVJ3NXH,anghi0m325,QR/anghi0m325.png
+Still Loving You,Scorpions,1984,Love at First Sting,https://music.youtube.com/watch?v=vJrYN-_BXws&si=OjtjpZeELfMA_V8V,anghi0m326,QR/anghi0m326.png
+Stinkfist,Tool,1996,Ænima,https://music.youtube.com/watch?v=NfpwKs1REg0&si=_djl8kaHOBQFjkuV,anghi0m327,QR/anghi0m327.png
+Stockholm Syndrome,Muse,2003,Absolution,https://music.youtube.com/watch?v=_b7OanWbpjU&si=lv2r9WMKmlm_oig6,anghi0m328,QR/anghi0m328.png
+Stranded,Gojira,2016,Magma,https://music.youtube.com/watch?v=zgychWIo6UA&si=LI3SdCYSWMqXX8d1,anghi0m329,QR/anghi0m329.png
+Sudden Death,Megadeth,2010,Th1rt3en,https://music.youtube.com/watch?v=3f7Kly-72fc&si=tr_MuMJ__OB4cKtX,anghi0m330,QR/anghi0m330.png
+Summertime blues,Blue cheer,1968,Vincebus Eruptum,https://music.youtube.com/watch?v=o4vIlg4alz8&si=R18fWCoowcUrdtbS,anghi0m331,QR/anghi0m331.png
+Supernaut,Black Sabbath,1972,Vol. 4,https://music.youtube.com/watch?v=Ivj3TjsMgOg&si=rCGvQJtelpjj0GIZ,anghi0m332,QR/anghi0m332.png
+Symphony of Destruction,Megadeth,1992,Countdown to Extinction,https://music.youtube.com/watch?v=WdoXZf-FZyA&si=O_qHqnEhU0Uo2cHT,anghi0m333,QR/anghi0m333.png
+Take This Life,In Flames,2006,Come Clarity,https://music.youtube.com/watch?v=ys049o_a5CY&si=iZu-mCib65P6M_p1,anghi0m334,QR/anghi0m334.png
+Teardrops,Bring Me the Horizon,2020,Post Human: Survival Horror,https://music.youtube.com/watch?v=iKhHd9ySXEw&si=On-kcDL1RGS3j2e9,anghi0m335,QR/anghi0m335.png
+Tears Don’t Fall,Bullet for My Valentine,2006,The Poison,https://music.youtube.com/watch?v=aBafAljXzmM&si=julMo2rFkuKuoKRB,anghi0m336,QR/anghi0m336.png
+Ten Thousand Fists,Disturbed,2005,Ten Thousand Fists,https://music.youtube.com/watch?v=OuK4OcMUGcg&si=BzrQze6XKIU04ikK,anghi0m337,QR/anghi0m337.png
+Ten Ton Hammer,Machine Head,1997,The More Things Change...,https://music.youtube.com/watch?v=voMSeaiFodk&si=WdOcwWWu9GhykFh0,anghi0m338,QR/anghi0m338.png
+Territory,Sepultura,1993,Chaos A.D.,https://music.youtube.com/watch?v=5nUAcP3xa9k&si=fLe6lN6TAO1wS6ks,anghi0m339,QR/anghi0m339.png
+Teutonic Terror,Accept,2010,Blood of the Nations,https://music.youtube.com/watch?v=ral4hAS5dVk&si=jEe6aF-C8rIKdxGu,anghi0m340,QR/anghi0m340.png
+The bard's song - in the forest ,Blind Guardian ,1992,Somewhere Far Beyond,https://music.youtube.com/watch?v=TMSx95iU-yQ&si=YNfnIzvzeQOhavCr,anghi0m341,QR/anghi0m341.png
+The Beautiful People,Marilyn Manson,1996,Antichrist Superstar,https://music.youtube.com/watch?v=aFIwUqEiEnw&si=EXvQrOJMUSzT_AuL,anghi0m342,QR/anghi0m342.png
+The Catalyst ,Amaranthe,2024,The Catalyst ,https://music.youtube.com/watch?v=pHPle2QT5OM&si=h2tJSN-TzcvN4Awn,anghi0m343,QR/anghi0m343.png
+Oceans of Time,Axel Rudi Pell,1998,Oceans of Time,https://music.youtube.com/watch?v=c6fGcK4WSQ8&si=gA0lDV4uqF0yeQy3,anghi0m344,QR/anghi0m344.png
+The Devil in I,Slipknot,2014,.5: The Gray Chapter,https://music.youtube.com/watch?v=j6hzrg0JTu0&si=kuezdhDt3WxNNlCX,anghi0m345,QR/anghi0m345.png
+The Devil’s Orchard,Opeth,2011,Heritage,https://music.youtube.com/watch?v=cl_N5UA-QMo&si=omdAlZT8JvazkuFc,anghi0m346,QR/anghi0m346.png
+The Drapery Falls,Opeth,2001,Blackwater Park,https://music.youtube.com/watch?v=C-NkgmZZIkM&si=34mpeP3NUz7klSTq,anghi0m347,QR/anghi0m347.png
+The Eagle Flies Alone ,Arch Enemy,2017,Will to Power,https://music.youtube.com/watch?v=x5AcHMlaQv0&si=SCR61BfgXhPyRiYt,anghi0m348,QR/anghi0m348.png
+The End of Heartache,Killswitch Engage,2004,The End of Heartache,https://music.youtube.com/watch?v=h4QGc06KnBE&si=DRAOvbokv7uERYml,anghi0m349,QR/anghi0m349.png
+The fifth extinction ,Ayreon ,2008,01011001,https://music.youtube.com/watch?v=dJxUWtQbWrg&si=bT3Bq-TNYf_7vdG2,anghi0m350,QR/anghi0m350.png
+The Fight Song,Marilyn Manson,2000,Holy Wood (In the Shadow of the Valley of Death),https://music.youtube.com/watch?v=YMHKxCnl4k4&si=SM4dq4q4v9y1YPMT,anghi0m351,QR/anghi0m351.png
+Satellite 15.....The Final Frontier,Iron Maiden,2010,The Final Frontier,https://music.youtube.com/watch?v=jiOgT_uopI8&si=AceYqhKaLrepyBd2,anghi0m352,QR/anghi0m352.png
+The Grand Conjuration,Opeth,2005,Ghost Reveries,https://music.youtube.com/watch?v=8T37ufeQqkI&si=KhDh0xZhHaaE8-QG,anghi0m353,QR/anghi0m353.png
+The Heretic Anthem,Slipknot,2001,Iowa,https://music.youtube.com/watch?v=jd3fun04bNI&si=JfZudoAI6bCYZIxY,anghi0m354,QR/anghi0m354.png
+The Last in Line,Dio,1984,The Last in Line,https://music.youtube.com/watch?v=OjvZvRVk8Z0&si=6WxDlsgN6S_ZaOqD,anghi0m355,QR/anghi0m355.png
+The mission ,Van canto ,2006,A Storm to Come,https://music.youtube.com/watch?v=2DemXCdzTmE&si=1UH3uxXaE-1IWt9s,anghi0m356,QR/anghi0m356.png
+The Motherload,Mastodon,2014,Once More 'Round the Sun,https://music.youtube.com/watch?v=_3_nu2aVsOs&si=-4t_RxyTlhlQMR89,anghi0m357,QR/anghi0m357.png
+The Number of the Beast,Iron Maiden,1982,The Number of the Beast,https://music.youtube.com/watch?v=_WCCVqkTI9Q&si=bZSbuYVy28sr39MH,anghi0m358,QR/anghi0m358.png
+The Phalanx,Trivium,2021,In the Court of the Dragon,https://music.youtube.com/watch?v=7zk_QPQdP-w&si=i1x8EfHrKkVaERYT,anghi0m359,QR/anghi0m359.png
+The Philosopher,Death,1993,Individual Thought Patterns,https://music.youtube.com/watch?v=PhQ1Fe0oKPM&si=rt2O7fhLFyNl1N9J,anghi0m360,QR/anghi0m360.png
+The Sentinel,Judas Priest,1984,Defenders of the Faith,https://music.youtube.com/watch?v=6mtc9Inn-sQ&si=-1mfexRWsbfYDJzZ,anghi0m361,QR/anghi0m361.png
+The Seven Angels ,Avantasia ,2002,The Metal Opera Part II,https://music.youtube.com/watch?v=kuQCeNyFr5c&si=dCsv1il39P2kVqDj,anghi0m362,QR/anghi0m362.png
+The Silence ,Gamma Ray ,1990,Heading for Tomorrow,https://music.youtube.com/watch?v=9oR2T2UJIQM&si=ZSLiyxq6X6FGLMJA,anghi0m363,QR/anghi0m363.png
+The Sin and the Sentence,Trivium,2017,The Sin and the Sentence,https://music.youtube.com/watch?v=TNyFYvCyhdc&si=brLwe9uPfqoi5kU8,anghi0m364,QR/anghi0m364.png
+The Stage,Avenged Sevenfold,2016,The Stage,https://music.youtube.com/watch?v=8tKJ2dlm8q4&si=b6XpIYrQgeGkZK-b,anghi0m365,QR/anghi0m365.png
+The Summoning,Sleep Token,2023,Take Me Back to Eden,https://music.youtube.com/watch?v=Ywa4b2ZCnMk&si=Dzbuxdb26HtwTipa,anghi0m366,QR/anghi0m366.png
+The Trooper,Iron Maiden,1983,Piece of Mind,https://music.youtube.com/watch?v=W4DfbinBgL4&si=Eew0ywJFGqcnlFbL,anghi0m367,QR/anghi0m367.png
+The Weapon They Fear,Heaven Shall Burn,2004,Antigone,https://music.youtube.com/watch?v=xHj3PgfzovM&si=Ad5zVxnaoy40lmyD,anghi0m368,QR/anghi0m368.png
+Through the Fire and Flames,DragonForce,2006,Inhuman Rampage,https://music.youtube.com/watch?v=XkFz_hi2tWY&si=rqaPTOWCTYzLrTPg,anghi0m369,QR/anghi0m369.png
+Mein Eichensarg,Eisregen,2004,Wundwasser,https://music.youtube.com/watch?v=RGR4igeAtsQ&si=XV4s9exb_o9Hww0B,anghi0m370,QR/anghi0m370.png
+Tormentor,Destruction,1985,Infernal Overkill,https://music.youtube.com/watch?v=O0S8KI1Al_c&si=PVT0Qj2trpBfH9S-,anghi0m371,QR/anghi0m371.png
+Tortuga ,Mr. Hurley und die Pulveraffen ,2017,Tortuga ,https://music.youtube.com/watch?v=qSBvtHebzNU&si=B2IHGnmrDxdXfMOB,anghi0m372,QR/anghi0m372.png
+Toxicity,System of a Down,2001,Toxicity,https://music.youtube.com/watch?v=mUEsqQpact0&si=SqYX9hLlQ9kW1PTr,anghi0m373,QR/anghi0m373.png
+Transilvanian Hunger,Darkthrone,1994,Transilvanian Hunger,https://music.youtube.com/watch?v=KphlVeJX6fE&si=gOn1R93eDWp1_jCe,anghi0m374,QR/anghi0m374.png
+Träumst du (feat. Marta Jandová),Oomph!,2006,Delikatessen,https://music.youtube.com/watch?v=ZyYQQBoD624&si=qdJ-puYBVHWuJa-R,anghi0m375,QR/anghi0m375.png
+Tribute,Tenacious D,2002,Tenacious D,https://music.youtube.com/watch?v=lsrVFbMtfx4&si=sUXPsnhaDInLh71q,anghi0m376,QR/anghi0m376.png
+Twilight Of The Thunder God,Amon amarth ,2008,Twilight of the thunder god,https://music.youtube.com/watch?v=_y1j-d6aaIM&si=F9VT2ohej30KiBi8,anghi0m377,QR/anghi0m377.png
+Under Jolly Roger,Running Wild,1987,Under Jolly Roger,https://music.youtube.com/watch?v=ncHEGQvcW74&si=gKXfkfKo1GfEGizk,anghi0m378,QR/anghi0m378.png
+Unholy Confessions,Avenged Sevenfold,2003,Waking the Fallen,https://music.youtube.com/watch?v=36stRPPIy2w&si=crP9FzomQIc8JbZe,anghi0m379,QR/anghi0m379.png
+Universe on Fire ,Gloryhammer ,2015,Space 1992: Rise of the Chaos Wizards,https://music.youtube.com/watch?v=OaIObpuxj5s&si=PB-et-FK97-HshDR,anghi0m380,QR/anghi0m380.png
+Unsainted,Slipknot,2019,We Are Not Your Kind,https://music.youtube.com/watch?v=XYZue7_NQew&si=czQjc5_KMqOA0bXy,anghi0m381,QR/anghi0m381.png
+Valhalla,Blind Guardian,1989,Follow the Blind,https://music.youtube.com/watch?v=4w9uy4Ip5Zs&si=WnRPCC8h_mK681mH,anghi0m382,QR/anghi0m382.png
+Valhalleluja,Nanowar of Steel,2018,Stairway to Valhalla,https://music.youtube.com/watch?v=QNmG6nO7k8w&si=swAWVoRU5h2LI8UL,anghi0m383,QR/anghi0m383.png
+Valley of the Damned,DragonForce,2003,Valley of the Damned,https://music.youtube.com/watch?v=7tsYxnFp8pU&si=LgAMT2fKoTbIJ6NK,anghi0m384,QR/anghi0m384.png
+Valley of the queens ,Ayreon ,1998,Into the Electric Castle,https://music.youtube.com/watch?v=OYrOYj7-n3Y&si=qNZkwapDMsoP_Jzu,anghi0m385,QR/anghi0m385.png
+Vice Grip,Parkway Drive,2015,Ire,https://music.youtube.com/watch?v=5plRum8eEiw&si=isVTm2inkgO0p9Qy,anghi0m386,QR/anghi0m386.png
+Victim of Changes,Judas Priest,1976,Sad Wings of Destiny,https://music.youtube.com/watch?v=d26JrMKJAlE&si=7T7ej8YDGrtOBMot,anghi0m387,QR/anghi0m387.png
+Voice of the Soul,Death,1998,The Sound of Perseverance,https://music.youtube.com/watch?v=s2EJ1AqPIPg&si=RfrfmShG-UG6moj9,anghi0m388,QR/anghi0m388.png
+Vollmond,In Extremo,2001,Sünder ohne Zügel,https://music.youtube.com/watch?v=-5N7CxfMKoE&si=JLa_rDPob_dMMjo0,anghi0m389,QR/anghi0m389.png
+Vore,Sleep Token,2023,Take Me Back to Eden,https://music.youtube.com/watch?v=2ncWrZO1dvY&si=TMJifiHWdWbwybxZ,anghi0m390,QR/anghi0m390.png
+Walk,Pantera,1992,Vulgar Display of Power,https://music.youtube.com/watch?v=kOV2iTeGQik&si=0gRLnbDwe3i7Al6s,anghi0m391,QR/anghi0m391.png
+Walk with Me in Hell,Lamb of God,2006,Sacrament,https://music.youtube.com/watch?v=iP6n1LK0NxA&si=DawpGTWE5wyrsGsC,anghi0m392,QR/anghi0m392.png
+War pigs,Black Sabbath,1970,Paranoid,https://music.youtube.com/watch?v=f-e8-DUqt0I&si=yqQJDwnyIg3AJSL9,anghi0m393,QR/anghi0m393.png
+Man on a Mission,Gamma Ray,1995,Land of the Free,https://music.youtube.com/watch?v=IgoWZFIQpJo&si=nZOe3-9sfaBNPV3M,anghi0m394,QR/anghi0m394.png
+Wasted Years,Iron Maiden,1986,Somewhere in Time,https://music.youtube.com/watch?v=ULsr-fFVjVs&si=bKekp3LApV2Jgx__,anghi0m395,QR/anghi0m395.png
+We are pirates ,Orden Ogan ,2010,"Easton Hope
+ ",https://music.youtube.com/watch?v=-c0Xx9ktQNA&si=VHQEdH558eZ8G2Nv,anghi0m396,QR/anghi0m396.png
+We Will Rise,Arch Enemy,2003,Anthems of Rebellion,https://music.youtube.com/watch?v=wmxU9OQLq-E&si=nRehZbjAAlCC8uPu,anghi0m397,QR/anghi0m397.png
+We’re Not Gonna Take It,Twisted Sister,1984,Stay Hungry,https://music.youtube.com/watch?v=orsonBB3Lf4&si=Pti4HH2trF1nSvZj,anghi0m398,QR/anghi0m398.png
+Where Dead Angels Lie,Dissection,1995,Storm of the Light's Bane,https://music.youtube.com/watch?v=rHUNN-yIwf8&si=Q9EH81FyWsoKvECj,anghi0m399,QR/anghi0m399.png
+Where the Slime Live,Morbid Angel,1995,Domination,https://music.youtube.com/watch?v=6Qa1nO_AovI&si=aC8IZna7B8HSxUrT,anghi0m400,QR/anghi0m400.png
+Whole lotta love,Led Zeppelin,1969,Led Zeppelin II,https://music.youtube.com/watch?v=0bcIjILqORM&si=-09M-VHL7GZ-vrzY,anghi0m401,QR/anghi0m401.png
+Whole Lotta Rosie,AC/DC,1977,Let There Be Rock,https://music.youtube.com/watch?v=bAOwDZoWXRI&si=P8NzCR5u3-ZDKRPm,anghi0m402,QR/anghi0m402.png
+Whore,In This Moment,2012,Blood,https://music.youtube.com/watch?v=j7erjahh46Q&si=tADb-PZuyaRrCt2b,anghi0m403,QR/anghi0m403.png
+Widow,Paradise Lost,1993,Icon,https://music.youtube.com/watch?v=-1sjJKJcQlI&si=l_at4QRpX2efVpz4,anghi0m404,QR/anghi0m404.png
+Wax Wings,Periphery,2023,Periphery V: Djent Is Not a Genre,https://music.youtube.com/watch?v=ClU3pyDStR0&si=bEv3gCzYHmu-UfTW,anghi0m405,QR/anghi0m405.png
+Wind of Change,Scorpions,1990,Crazy World,https://music.youtube.com/watch?v=Ukh1zoiV304&si=zLgX014ipOeo-SO6,anghi0m406,QR/anghi0m406.png
+Windowpane,Opeth,2003,Damnation,https://music.youtube.com/watch?v=AWCVHllzG9Y&si=HvfW4RDmKfUJFnZO,anghi0m407,QR/anghi0m407.png
+Wish I Had an Angel,Nightwish,2004,Once,https://music.youtube.com/watch?v=yGdWuOCWXcY&si=hBq7oKyGAIaK25Wg,anghi0m408,QR/anghi0m408.png
+Yggdrasil,Brothers of metal ,2017,Prophecy of Ragnarök,https://music.youtube.com/watch?v=3GicPBWG5EM&si=RZIcsCChUWUm2Dja,anghi0m409,QR/anghi0m409.png
+You really got me,Kinks,1964,Kinks,https://music.youtube.com/watch?v=bZ4uGV6Goy0&si=1ZMfQuqxmXDkRsE9,anghi0m410,QR/anghi0m410.png
+You’ve Got Another Thing Comin’,Judas Priest,1982,Screaming for Vengeance,https://music.youtube.com/watch?v=LNyIhirtXUI&si=z3C__LTT-1AvxMTc,anghi0m411,QR/anghi0m411.png
+Zeig mir den Weg nach unten ,Knorkator ,1999,Hasenchartbreaker,https://music.youtube.com/watch?v=zOeBVmG50q4&si=gnK0uu3T302nBpSc,anghi0m412,QR/anghi0m412.png
+Zombie,Bad Wolves,2018,Disobey,https://music.youtube.com/watch?v=qG6_d9tpR84&si=YIdxB4bpM9j7rVTm,anghi0m413,QR/anghi0m413.png
+In the End,Linkin Park,2000,Hybrid Theory,https://music.youtube.com/watch?v=BLZWkjBXfN8&si=-lxJjuB6QhvT4MCL,anghi0m414,QR/anghi0m414.png
+Bring Me To Life,Evanescence,2003,Falen,https://music.youtube.com/watch?v=-eGM0IJc70Y&si=0bihayWrCcXAtDoQ,anghi0m415,QR/anghi0m415.png
+My Immortal,Evanescence,2003,Falen,https://music.youtube.com/watch?v=NNsieYrAxkc&si=XWRKSYU2Ko0-ahGo,anghi0m416,QR/anghi0m416.png
+Welcome to the Black Parade,My Chemical Romance,2006,The Black Parade,https://music.youtube.com/watch?v=v_uncMEJkBc&si=a4KhpoIv69aakxmT,anghi0m417,QR/anghi0m417.png
+Pasadena 1994 (feat. Joakim Broden),Nanowar of Steel ,2003,Dislike to False Metal,https://music.youtube.com/watch?v=cA-43XXwq5k&si=MJrmTC1jPNwWtpKW,anghi0m418,QR/anghi0m418.png
+Uranus,Nanowar of Steel,2018,Stairway to Valhalla,https://music.youtube.com/watch?v=enPbq4whq1c&si=oWjBsYY-UyYbATO9,anghi0m419,QR/anghi0m419.png
+Wishmaster,Nightwish,2000,Wishmaster,https://music.youtube.com/watch?v=2ZV9Snsk3vU&si=oGRZsKhmGyL_0yEd,anghi0m420,QR/anghi0m420.png
+Bye Bye Beautiful,Nightwish,2007,"
+Dark Passion Play",https://music.youtube.com/watch?v=CacWfWX-rw4&si=XfDz1WQnnd-4K_iT,anghi0m421,QR/anghi0m421.png
+Deutschland,Rammstein,2019,Rammstein,https://music.youtube.com/watch?v=vGtaDvhSxaI&si=Y-tcDK4mwrWYmZA6,anghi0m422,QR/anghi0m422.png
+Kreuzfeuer,Powerwolf,2013,"
+Preachers of the Night",https://music.youtube.com/watch?v=XEtc5aYWJbE&si=MM4xsS_CAov2W2c6,anghi0m423,QR/anghi0m423.png
+Prometheus,Saltatio Mortis,2007,Aus Der Asche,https://music.youtube.com/watch?v=3lHidm3010Q&si=lhJIRkSqrsc5BBGy,anghi0m424,QR/anghi0m424.png
+Drachentöter,Schandmaul ,2004,Wie Pech und Schwefel,https://music.youtube.com/watch?v=YTeBgWvuLUo&si=rrbfBfeC1IVxmgoJ,anghi0m425,QR/anghi0m425.png
+Walpurgisnacht,Schandmaul ,2002,Narrenkonig ,https://music.youtube.com/watch?v=xYubLwVzFZo&si=NifhKsg6XJuy3era,anghi0m426,QR/anghi0m426.png
+Herren der Winde,Schandmaul ,2001,Von Spitzbuben und anderen Halunken,https://music.youtube.com/watch?v=HbHRGcnPeIk&si=-5aIBKrO4KSBB9Bx,anghi0m427,QR/anghi0m427.png
+Ausgebombt,Sodom,1989,Agent Orange,https://music.youtube.com/watch?v=-qmbiw38o2I&si=I6k8sHRwXqvT3qeM,anghi0m428,QR/anghi0m428.png
+Blitzkrieg,"
+Deathstars",2006,Termination Bliss,https://music.youtube.com/watch?v=_rbOiEI1ZKc&si=K-NB8tgtXHlXjkGk,anghi0m429,QR/anghi0m429.png
+Lonely Day,System of a Down,2005,Hypnotize,https://music.youtube.com/watch?v=9VBiJvJfC0Q&si=u1jsNSjMm_M8HxSz,anghi0m430,QR/anghi0m430.png
+Sugar,System of a Down,1998,System of a Down,https://music.youtube.com/watch?v=JYWYcgxOz_M&si=mQQQLAnsisNbxFMm,anghi0m431,QR/anghi0m431.png
+Roulette,System of a Down,2002,Steal This Album!,https://music.youtube.com/watch?v=ByBhN_X5nVg&si=ULFrE2J5y3s7Oriz,anghi0m432,QR/anghi0m432.png
+Kickapoo,Tenacious D,2006,The Pick Of Destiny,https://music.youtube.com/watch?v=eB3cyu27Ghk&si=aJBfOufE2ZXNNS56,anghi0m433,QR/anghi0m433.png
+Wild Child,W.A.S.P.,1985,The Last Command,https://music.youtube.com/watch?v=D6qEQeYYveQ&si=xdbqb_J2IqT4tome,anghi0m434,QR/anghi0m434.png

--- a/app/src/main/java/de/arschwasser/angelo/core/CSVImporter.kt
+++ b/app/src/main/java/de/arschwasser/angelo/core/CSVImporter.kt
@@ -12,14 +12,15 @@ object CSVImporter {
         val songs = withContext(Dispatchers.IO) {
             csvReader().readAllWithHeader(bytes.inputStream()).map { row ->
                 Song(
-                    title = row["Title"] ?: "",
-                    artist = row["artist"] ?: "",
-                    year = row["year"]?.toIntOrNull() ?: 0,
-                    code = row["code"] ?: "",
+                    title = row["Title"] ?: row["title"] ?: "",
+                    artist = row["artist"] ?: row["Artist"] ?: "",
+                    year = row["year"]?.toIntOrNull()
+                        ?: row["Year"]?.toIntOrNull() ?: 0,
+                    code = row["code"] ?: row["Code"] ?: "",
 //                    spotify = row["Spotify"],
                     spotify = null,
-                    youtube = row["YouTube"],
-                    album = row["Album"],
+                    youtube = row["YouTube"] ?: row["youtube"],
+                    album = row["Album"] ?: row["album"],
                     edition = fileName
                 )
             }

--- a/app/src/main/java/de/arschwasser/angelo/ui/screens/SelectVersionScreen.kt
+++ b/app/src/main/java/de/arschwasser/angelo/ui/screens/SelectVersionScreen.kt
@@ -92,22 +92,21 @@ fun SelectVersionScreen(nav: NavHostController) {
                 onClick = {
                     view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
                     scope.launch {
-                        val json =
-                            Downloader.getString(AppConfig.BASE_URL + AppConfig.CSV_LIST_PATH)
-                        val arr = JSONObject(json).getJSONArray("versions")
-                        if (arr.length() > 0) {
-                            val obj = arr.getJSONObject(0) // first entry for simplicity
-                            val bytes =
-                                Downloader.getBytes("${AppConfig.BASE_URL}/csv/${obj.getString("filename")}")
-                            val filename = obj.getString("filename")
-                            CSVImporter.import(ctx, bytes, filename)
-                            pref.setGameVersion(filename)
-                            view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
-                            nav.popBackStack()
-                        }
+                        val url =
+                            "https://docs.google.com/spreadsheets/d/e/2PACX-1vTyp8b7UmapJwCy033FMglAABejMpNQB0ezt2dCTR-CSh1WqLB3L0xjTkA1zr6_pEyDnmbIkS9X40CC/pub?gid=0&single=true&output=csv"
+                        // previous server import:
+                        // val json = Downloader.getString(AppConfig.BASE_URL + AppConfig.CSV_LIST_PATH)
+                        // val arr = JSONObject(json).getJSONArray("versions")
+                        // val obj = arr.getJSONObject(0)
+                        // val oldUrl = "${'$'}{AppConfig.BASE_URL}/csv/${'$'}{obj.getString("filename")}"
+                        val bytes = Downloader.getBytes(url)
+                        CSVImporter.import(ctx, bytes, "server.csv")
+                        pref.setGameVersion("server.csv")
+                        view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+                        nav.popBackStack()
                     }
                 },
-                enabled = false
+                enabled = true
             ) { Text("Server") }
 
             Button(onClick = {


### PR DESCRIPTION
## Summary
- bundle default songs CSV
- make CSVImporter accept mixed-case headers
- load bundled CSV into database on first app launch
- fetch server CSV directly from Google Sheets
- gracefully ignore missing default CSV
- keep old server URL path as comment

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68596cd8ace0832489f958d13190eb8f